### PR TITLE
OnRemove - Remove root Elements

### DIFF
--- a/src/SortableTree.tsx
+++ b/src/SortableTree.tsx
@@ -216,7 +216,7 @@ export function SortableTree<
               indicator={indicator}
               collapsed={Boolean(item.collapsed && item.children?.length)}
               onCollapse={item.children?.length ? handleCollapse : undefined}
-              onRemove={handleRemove}
+              onRemove={(event) => {event.stopPropagation(); handleRemove(); }}
               isLast={
                 item.id === activeId && projected
                   ? projected.isLast

--- a/src/SortableTreeItem.tsx
+++ b/src/SortableTreeItem.tsx
@@ -97,7 +97,7 @@ const SortableTreeItemNotMemoized = function SortableTreeItem<
         ...listeners,
       }}
       onCollapse={localCollapse}
-      onRemove={localRemove}
+      onRemove={(event) => {event.stopPropagation(); localRemove(); }}
       disableSorting={disableSorting}
     />
   );

--- a/stories/components/folder/FolderTreeItem.tsx
+++ b/stories/components/folder/FolderTreeItem.tsx
@@ -21,7 +21,9 @@ export const FolderTreeItem = forwardRef<
     >
       <span className={styles.Text}>{item.text}</span>
       <span className={styles.Text}>{item.date.getDate()}</span>
-      {!clone && onRemove && <button onClick={onRemove}>X</button>}
+      {!clone && onRemove && <button onClick={(event) => {
+        event.stopPropagation(); onRemove()
+      }}>X</button>}
       {clone && childCount && childCount > 1 ? (
         <span className={styles.Count}>{childCount}</span>
       ) : null}

--- a/stories/components/tree/TreeItem.tsx
+++ b/stories/components/tree/TreeItem.tsx
@@ -14,7 +14,10 @@ export const TreeItem = forwardRef<
     <SimpleTreeItemWrapper {...props} ref={ref}>
       <span className={styles.Text}>{item.text}</span>
       <span className={styles.Text}>{item.date.getDate()}</span>
-      {!clone && onRemove && <button onClick={onRemove}>X</button>}
+      {!clone && onRemove && <button onClick={(event) => {
+        event.stopPropagation();
+        onRemove();
+      }}>X</button>}
       {clone && childCount && childCount > 1 ? (
         <span className={styles.Count}>{childCount}</span>
       ) : null}


### PR DESCRIPTION
Adding Event stop propagation before the run onRemove function will allow  the following actions :
- Delete Root parents ( before it was toggling on/off the tree list )
- Delete children (works as expected as before). 