### PR TITLE
add option to disable styling in SimpleTreeItemWrapper

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,11 @@ export type TreeItemComponentProps<T = {}> = {
   disableSorting?: boolean;
 
   /*
+  If true will remove default styling
+  */
+  disableStyling?: boolean;
+
+  /*
   True if the item is the last one among it's parent children.
   Might be important for e.g. FolderTreeItemWrapper to show correct images.
    */

--- a/src/ui/simple/SimpleTreeItemWrapper.tsx
+++ b/src/ui/simple/SimpleTreeItemWrapper.tsx
@@ -13,6 +13,7 @@ export const SimpleTreeItemWrapper = forwardRef<
     disableSelection,
     disableInteraction,
     disableSorting,
+    disableStyling,
     ghost,
     handleProps,
     indentationWidth,
@@ -55,7 +56,11 @@ export const SimpleTreeItemWrapper = forwardRef<
       }}
     >
       <div
-        className={clsx('dnd-sortable-tree_simple_tree-item', contentClassName)}
+        className={
+          disableStyling
+            ? undefined
+            : clsx('dnd-sortable-tree_simple_tree-item', contentClassName)
+        }
         ref={ref}
         {...(manualDrag ? undefined : handleProps)}
         onClick={disableCollapseOnItemClick ? undefined : onCollapse}


### PR DESCRIPTION
I have a use case for this but want to have total control of the styling.
This adds an option to skip the `className` in `SimpleTreeItemWrapper`